### PR TITLE
Help VC++ Code Analysis

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1540,7 +1540,7 @@ z_streamp source;
     struct inflate_state FAR *state;
     struct inflate_state FAR *copy;
     unsigned char FAR *window;
-    unsigned wsize;
+    unsigned wsize = 0;
 
     /* check input */
     if (inflateStateCheck(source) || dest == Z_NULL)


### PR DESCRIPTION
During some CA work in the dotnet runtime project we discovered the VC++ code analysis has trouble determining the following value is properly initialized prior to use. Instead of adding a suppression it seemed easier to simply initialize it.

See https://github.com/dotnet/runtime/pull/49194#discussion_r597766961 for context.