### PR TITLE
Address C4244 warnings in MSVC build

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1553,10 +1553,10 @@ local block_state deflate_stored(s, flush)
         _tr_stored_block(s, (char *)0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
-        s->pending_buf[s->pending - 4] = len;
-        s->pending_buf[s->pending - 3] = len >> 8;
-        s->pending_buf[s->pending - 2] = ~len;
-        s->pending_buf[s->pending - 1] = ~len >> 8;
+        s->pending_buf[s->pending - 4] = (Bytef)len;
+        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
+        s->pending_buf[s->pending - 2] = (Bytef)~len;
+        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
 
         /* Write the stored block header bytes. */
         flush_pending(s->strm);

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -136,7 +136,7 @@ local inline void quick_send_bits(deflate_state *z_const s, z_const int value,
 
     b = w >> 3;
     s->pending += b;
-    s->bi_buf =  out >> (b << 3);
+    s->bi_buf = (ush)(out >> (b << 3));
     s->bi_valid = w - (b << 3);
 }
 
@@ -224,7 +224,7 @@ block_state deflate_quick(deflate_state *s, int flush)
         }
 
         if (s->lookahead >= MIN_MATCH) {
-            hash_head = quick_insert_string(s, s->strstart);
+            hash_head = quick_insert_string(s, (Pos)s->strstart);
             dist = s->strstart - hash_head;
 
             if ((dist-1) < (s->w_size - 1)) {

--- a/slide_sse.c
+++ b/slide_sse.c
@@ -18,7 +18,7 @@ void slide_hash_sse(deflate_state *s)
     unsigned n;
     Posf *p;
     uInt wsize = s->w_size;
-    z_const __m128i xmm_wsize = _mm_set1_epi16(s->w_size);
+    z_const __m128i xmm_wsize = _mm_set1_epi16((short)s->w_size);
 
     n = s->hash_size;
     p = &s->head[n] - 8;

--- a/trees.c
+++ b/trees.c
@@ -717,7 +717,7 @@ local void scan_tree(s, tree, max_code)
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq += (ush)count;
         } else if (curlen != 0) {
             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
             s->bl_tree[REP_3_6].Freq++;


### PR DESCRIPTION
Allows the MSVC build to compile clean when the [C4244 warning code](https://learn.microsoft.com/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244) (checking for potentially lossy implicit integer narrowing casts) is enabled. I've tried to follow the same coding conventions already used throughout the project.

The changes to **deflate.c** and **trees.c** are the same as I submitted to https://github.com/madler/zlib/pull/852. See that PR for discussion. If you're going to rebase on madler/zlib at some future point, then perhaps you might opt to leave these changes out of this repo, instead pulling in the changes the next time you take a rebase.

The change to **deflate_quick.c (line 139)** appears correct because at the start of the method, the *value* argument fits cleanly into a 16-bit integer (confirmed by checking the three call sites), *length* is no greater than 16, and *bi_valid* is no greater than 16. This means that lines 128 - 130 won't result in a loss of fidelity. By the time line 137 is reached, *out* will contain at most 7 unpended / unflushed bits, so the narrowing conversion to a 16-bit backing field (line 139) is lossless.

I cannot convince myself of the correctness of **deflate_quick.c (line 227)** because I cannot easily follow the logic backward. I assume the narrowing conversion here is intentional, but I would feel more comfortable if a project maintainer would validate this assumption.

The change to **slide_sse.c** appears correct because the value of *w_size* is limited to `1 << 15`. See below.

https://github.com/intel/zlib/blob/d9c2508ff9493514b1ef9851eb9623a7fae3a4c0/deflate.c#L306-L310

https://github.com/intel/zlib/blob/d9c2508ff9493514b1ef9851eb9623a7fae3a4c0/deflate.c#L325-L326